### PR TITLE
Global stmts

### DIFF
--- a/src/parser/print_visitor.rs
+++ b/src/parser/print_visitor.rs
@@ -116,6 +116,16 @@ impl WhammVisitor<String> for AsStrVisitor {
             self.decrease_indent();
         }
 
+        // print global statements
+        if !script.global_stmts.is_empty() {
+            s += &format!("{} script global statements:{}", self.get_indent(), NL);
+            self.increase_indent();
+            for stmt in script.global_stmts.iter() {
+                s += &format!("{} {};{}", self.get_indent(), self.visit_stmt(stmt), NL);
+            }
+            self.decrease_indent();
+        }
+
         // print providers
         s += &format!("{} script providers:{}", self.get_indent(), NL);
         for (name, provider) in script.providers.iter() {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -485,7 +485,6 @@ fn test_global_stmts() {
         BEGIN{
             strcmp((arg0, arg1), "bookings");
         }
-        a = 10;
         END {
             a = 2;
         }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -470,6 +470,41 @@ pub fn testing_strcmp() {
         }
     };
 }
+
+#[test]
+fn test_global_stmts() {
+    setup_logger();
+    let mut err = ErrorGen::new("".to_string(), "".to_string(), 0);
+    let script = r#"
+        i32 a;
+        a = 1;
+        dummy_fn() {
+            a = strcmp((arg0, arg1), "bookings");
+            strcmp((arg0, arg1), "bookings");
+        }
+        BEGIN{
+            strcmp((arg0, arg1), "bookings");
+        }
+        a = 10;
+        END {
+            a = 2;
+        }
+    "#;
+
+    match get_ast(script, &mut err) {
+        Some(ast) => {
+            print_ast(&ast);
+        }
+        None => {
+            error!("Could not get ast from script: {}", script);
+            if err.has_errors {
+                err.report();
+            }
+            assert!(!err.has_errors);
+        }
+    };
+}
+
 #[test]
 pub fn testing_block() {
     setup_logger();

--- a/src/parser/whamm.pest
+++ b/src/parser/whamm.pest
@@ -3,7 +3,7 @@
 // ==============================
 
 // supports top-level global declarations/initial assignments and probe definitions
-script = { SOI ~ (statement | fn_def)* ~ probe_def ~ (statement | fn_def | probe_def)* ~ EOI }
+script = { SOI ~ (statement | fn_def)* ~ probe_def ~ (fn_def | probe_def)* ~ EOI }
  
 // TODO -- support comma separated list of specs: https://docs.oracle.com/cd/E23824_01/html/E22973/glghi.html#scrolltoc
 probe_def = { PROBE_SPEC ~ PUSH(predicate?) ~ "{" ~ statement* ~ "}" }


### PR DESCRIPTION
deals with #66 

@wavid-b can you check the output for `test_global_stmts`? The script
```DTrace
        i32 a;
        a = 1;
        dummy_fn() {
            a = strcmp((arg0, arg1), "bookings");
            strcmp((arg0, arg1), "bookings");
        }
        BEGIN{
            strcmp((arg0, arg1), "bookings");
        }
        a = 10;
        END {
            a = 2;
        }
```
Gives me the following AST:
```
---- parser::tests::test_global_stmts stdout ----
Whamm functions:
-- strcmp (str_addr: (int, int), value: str) -> bool {
-- }

Scripts:
-- `script0`:
---- user defined functions:
------ dummy_fn () -> () {
-------- a = strcmp((arg0, arg1), "bookings");
-------- strcmp((arg0, arg1), "bookings");
-------- return ();
------ }

---- script global statements:
------ a = 10;
---- script providers:
------ `whamm` {
-------- packages:
---------- `` {
------------ package events:
-------------- `` {
---------------- event probe_map:
------------------ begin: (
------------------ `BEGIN` probe {
-------------------- `predicate`:
---------------------- / None /
-------------------- `body`:
---------------------- strcmp((arg0, arg1), "bookings");
------------------ }
------------------ `BEGIN` probe {
-------------------- `predicate`:
---------------------- / None /
-------------------- `body`:
---------------------- a = 2;
------------------ }
)
-------------- }
---------- }
------ }
```

I also have a question on 
```rust
pub struct Script {
    pub name: String,
    /// The providers of the probes that have been used in the Script.
    pub providers: HashMap<String, Provider>,
    pub fns: Vec<Fn>,                     // User-provided
    pub globals: HashMap<String, Global>, // User-provided, should be VarId
    pub global_stmts: Vec<Statement>,
}
```
What does user-provided global means? What is the different between `globals` and `global_stmts`? Since declaring a global in front of script is `Statement::Decl`